### PR TITLE
Prevent URL from being printed for each API request

### DIFF
--- a/pollster/pollster.py
+++ b/pollster/pollster.py
@@ -21,7 +21,6 @@ class Pollster(object):
         url = "http://%s%s/%s" % (self.API_SERVER, self.API_BASE, path)
         if params:
           url += "?%s" % urlencode(params)
-        print url
         return url
 
     def _invoke(self, path, params={}):


### PR DESCRIPTION
I can see no useful reason for printing the url other than debugging- otherwise all it does is clutter up output.