### PR TITLE
Making python-pollster run in python 2.7 and 3.5

### DIFF
--- a/pollster/pollster.py
+++ b/pollster/pollster.py
@@ -7,6 +7,7 @@ may be found at http://elections.huffingtonpost.com/pollster/api.
 from future.moves.urllib.parse import urlencode
 from future.moves.urllib.request import urlopen
 from future.moves.urllib.error import HTTPError
+from future.utils import iteritems
 
 try:
     import json
@@ -46,7 +47,7 @@ class Pollster(object):
                                                                 url_exc.reason)
             try:
                 r_msg = dict(json.loads(res))
-                if r_msg.has_key('errors'):
+                if 'errors' in r_msg:
                     msg += " [%s]" % r_msg['errors'][0]
             except ValueError:
                 pass
@@ -86,11 +87,11 @@ class Chart(object):
                  'topic',
                  'state',
                  'slug', ]
-        for key, val in result.iteritems():
+        for key, val in iteritems(result):
             if key in valid:
                 setattr(self, key, val)
 
-        if result.has_key('estimates_by_date'):
+        if 'estimates_by_date' in result:
             self._estimates_by_date = result['estimates_by_date']
 
     def polls(self, **kwargs):
@@ -132,7 +133,7 @@ class Poll(object):
                  'sponsors',
                  'partisan',
                  'affiliation']
-        for key, val in result.iteritems():
+        for key, val in iteritems(result):
             if key in valid:
                 setattr(self, key, val)
 

--- a/pollster/pollster.py
+++ b/pollster/pollster.py
@@ -4,8 +4,9 @@ Methods for accessing the HuffPost Pollster API. Documentation for this API
 may be found at http://elections.huffingtonpost.com/pollster/api.
 """
 
-import urllib2
-from urllib import urlencode
+from future.moves.urllib.parse import urlencode
+from future.moves.urllib.request import urlopen
+from future.moves.urllib.error import HTTPError
 
 try:
     import json
@@ -37,9 +38,9 @@ class Pollster(object):
             params = {}
         url = self._build_request_url(path, params)
         try:
-            response = urllib2.urlopen(url)
-        except urllib2.HTTPError as url_exc:
-            res = url_exc.read()
+            response = urlopen(url)
+        except HTTPError as url_exc:
+            res = url_exc.read().decode('utf-8')
             msg = "An error occurred. URL: %s Reason: %s %s" % (url,
                                                                 url_exc.code,
                                                                 url_exc.reason)
@@ -52,7 +53,7 @@ class Pollster(object):
             raise PollsterException(msg)
 
         if response.msg == 'OK':
-            return json.loads(response.read())
+            return json.loads(response.read().decode('utf-8'))
 
         raise PollsterException('Invalid response returned: %s', response.msg)
 

--- a/pollster/pollster.py
+++ b/pollster/pollster.py
@@ -49,7 +49,7 @@ class Pollster(object):
                     msg += " [%s]" % r_msg['errors'][0]
             except ValueError:
                 pass
-            raise PollsterException, msg
+            raise PollsterException(msg)
 
         if response.msg == 'OK':
             return json.loads(response.read())

--- a/tests.py
+++ b/tests.py
@@ -1,5 +1,4 @@
 import unittest
-import urllib2
 from pollster.pollster import Pollster, Chart, PollsterException
 
 class TestBasic(unittest.TestCase):


### PR DESCRIPTION
I made some changes to get python-pollster to run in both python 2.7 and 3.5. I tried to keep the changes to a minimum. Tests pass in both runtime environments.