### PR TITLE
Make pollster Python 2.7 and Python 3.5 compatible.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python:
+  - "2.7"
+  - "3.5"
+# command to install dependencies
+install: "python setup.py install"
+# command to run tests
+script: nosetests

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Pollster
+[![Build Status](https://travis-ci.org/alexandercbooth/python-pollster.svg?branch=master)](https://travis-ci.org/alexandercbooth/python-pollster)
 
-A Python wrapper for the [Pollster API](http://elections.huffingtonpost.com/pollster/api) 
+A Python wrapper for the [Pollster API](http://elections.huffingtonpost.com/pollster/api)
 which provides access to political opinion polling data and trend estimates from The Huffington Post.
 
 ## Installation

--- a/pollster/pollster.py
+++ b/pollster/pollster.py
@@ -3,11 +3,21 @@
 Methods for accessing the HuffPost Pollster API. Documentation for this API
 may be found at http://elections.huffingtonpost.com/pollster/api.
 """
+try:
+    from urllib.parse import urlencode
+    from urllib.request import urlopen
+    from urllib.error import HTTPError
 
-from future.moves.urllib.parse import urlencode
-from future.moves.urllib.request import urlopen
-from future.moves.urllib.error import HTTPError
-from future.utils import iteritems
+    def get_items(x):
+        return x.items()
+except ImportError:
+    from urllib2 import urlopen
+    from urllib2 import HTTPError
+    from urllib import urlencode
+
+    def get_items(x):
+        return x.viewitems()
+
 
 try:
     import json
@@ -87,7 +97,7 @@ class Chart(object):
                  'topic',
                  'state',
                  'slug', ]
-        for key, val in iteritems(result):
+        for key, val in get_items(result):
             if key in valid:
                 setattr(self, key, val)
 
@@ -133,7 +143,7 @@ class Poll(object):
                  'sponsors',
                  'partisan',
                  'affiliation']
-        for key, val in iteritems(result):
+        for key, val in get_items(result):
             if key in valid:
                 setattr(self, key, val)
 


### PR DESCRIPTION
I cloned the current repo and discovered that it did not install on my python 3.5 environment. I also tried it on my python 2 environment and it would not install there either. I then created two new vanilla conda python environments, one for 2.7 and one for 3.5 and made my changes and tested them against these environments. Both installed/worked fine after these changes. 

The environments I tested it out on are (if you have [conda](https://www.continuum.io/downloads) installed: `conda create -n py2pollster python=2.7` and `conda create -n py3pollster python=3.5`. 
Tests were also passed in both of these environments.
